### PR TITLE
Fix dotnet publish self contained parameter.

### DIFF
--- a/metadata/DotNet.json
+++ b/metadata/DotNet.json
@@ -610,7 +610,7 @@
           {
             "name": "SelfContained",
             "type": "bool",
-            "format": "--self-contained",
+            "format": "--self-contained {value}",
             "help": "Publishes the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine. If a runtime identifier is specified, its default value is <c>true</c>. For more infomation about the different deployment types, see <a href=\"https://docs.microsoft.com/en-us/dotnet/core/deploying/index\">.NET Core application deployment</a>."
           },
           {


### PR DESCRIPTION
If the value is not appended the cli reports an error:

```
> "C:\Program Files\dotnet\dotnet.exe" publish E:\arodes\Sample\Sample.sln --configuration Debug --no-restore --self-contained /p:AssemblyVersion=0.1.0.0 /p:FileVersion=0.1.0-ci.1 /p:InformationalVersion=0.1.0-ci.1+Branch.master.Sha.1eef508
C:\Program Files\dotnet\sdk\2.0.2\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.targets(130,23): error MSB4030: "/p:AssemblyVersion=0.1.0.0" is an invalid value for the "IsSelfContained" parameter of the "GenerateDepsFile" task. The "IsSelfContained" parameter is of type "System.Boolean". [E:\arodes\Sample\src\Sample.Api.Client\Sample.Api.Client.csproj]
```
